### PR TITLE
Improve Spain's Postal Code RegEx and Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Below are the patterns for each European country, along with a brief description
 - **Description:** Matches Spanish phone numbers. Begins with +34, followed by a digit from 6 to 9, and then 8 more digits.
 ##### Postal Code
 - **Pattern:** `^(?:0[1-9]|[1-4]\d|5[0-2])\d{3}$`
-- **Description:** Spanish postal codes consist of 5 digits. The first two indicate the province, the third one a large town or main delivery rounds, and the last two digits the delivery area and the secondary delivery route or link to rural areas.
+- **Description:** Spanish postal codes consist of 5 digits. The first two indicate the province, the third one a large town, city or main delivery rounds, and the last two digits the delivery area and the secondary delivery route or link to rural areas.
 ##### VAT Number
 - **Pattern:** `^ES[A-Z]\d{7}[A-Z]$|^ES[A-Z][0-9]{7}[0-9A-Z]$|^ES[0-9]{8}[A-Z]$`
 - **Description:** Spanish VAT numbers start with "ES", followed by various formats including a letter, 7 digits, then a letter; or 8 digits then a letter.

--- a/README.md
+++ b/README.md
@@ -510,8 +510,8 @@ Below are the patterns for each European country, along with a brief description
 - **Pattern:** `^\+34[6-9][0-9]{8}$`
 - **Description:** Matches Spanish phone numbers. Begins with +34, followed by a digit from 6 to 9, and then 8 more digits.
 ##### Postal Code
-- **Pattern:** `^\d{5}$`
-- **Description:** Matches Spanish postal codes, which consist of 5 digits.
+- **Pattern:** `^(?:0[1-9]|[1-4]\d|5[0-2])\d{3}$`
+- **Description:** Spanish postal codes consist of 5 digits. The first two indicate the province, the third one a large town or main delivery rounds, and the last two digits the delivery area and the secondary delivery route or link to rural areas.
 ##### VAT Number
 - **Pattern:** `^ES[A-Z]\d{7}[A-Z]$|^ES[A-Z][0-9]{7}[0-9A-Z]$|^ES[0-9]{8}[A-Z]$`
 - **Description:** Spanish VAT numbers start with "ES", followed by various formats including a letter, 7 digits, then a letter; or 8 digits then a letter.


### PR DESCRIPTION
Hello! 👋🏻 

I'm a Spanish BackEnd Engineer and I just found this repo, and while checking the section related to Spain I noticed that the current RegEx checking the Postal Code isn't entirely correct.

A Spanish postal code is composed of the following (in order) sections:

- The first and second digit are related to the provinces of the country, which are 52.
- The third digit is related to a large town or city.
- The fourth and fifth digits are related to delivery areas, secondary routes and rural areas.

So, the **first digit** is only valid if it's between **[0-5]**.
The **second digit** is valid when it's **[0-9]**, except when the **first digit** is **5**. In that case, the only valid values for this position are **[0-2]**.

