### PR TITLE
Fix incorrect VAT number regex for Cyprus

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Below are the patterns for each European country, along with a brief description
 - **Pattern:** `^\d{4}$`
 - **Description:** Cypriot postal codes consist of 4 digits. This pattern matches a sequence of exactly four numerical digits.
 ##### VAT Number
-- **Pattern:** `^CY\d{8}L$`
+- **Pattern:** `^CY\d{8}[A-Z]$`
 - **Description:** Cypriot VAT numbers start with "CY", followed by 8 digits and a final letter.
 
 ---


### PR DESCRIPTION
Cyprus has the last character as a checksum and is a letter between A and Z.

https://vatdb.com/guides/validate-cy-vat-number/